### PR TITLE
Fixed invalid/bad formatted URL problem at standart websites

### DIFF
--- a/scraper/ie.py
+++ b/scraper/ie.py
@@ -39,10 +39,9 @@ class IndustrialEngineering:
             try:
                 url = self.complete_url(document.find('a').get('href'))
             except AttributeError:
-                print("ERROR: Attribute error for scraping URL")
                 url = None
 
             new_announcements.append(
                 {'title': title, 'content': content, 'url': url})
 
-        return new_announcements        
+        return new_announcements

--- a/scraper/standart.py
+++ b/scraper/standart.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+import re
 
 
 class StandartDepartment:
@@ -8,9 +9,23 @@ class StandartDepartment:
         self.name = name
         self.address = address
 
+    def fix_invalid_url(self, text):
+        valid_path_pattern = r'(-\d+)$'
+        invalid_path_pattern = r'\/([^\/]+-\d+)$'
+        if re.search(invalid_path_pattern, text) == None:
+            return text
+        found_suffix = re.search(valid_path_pattern, text).group(1)
+
+        text = re.sub(invalid_path_pattern, '/' + found_suffix, text)
+        return text
+
     def complete_url(self, text):
+        text = self.fix_invalid_url(text)
         if text[:4] == 'http' or text[:3] == 'www':
             return text
+
+        if (text[0] == '/'):
+            text = text[1:]
 
         return self.address + text
 
@@ -33,6 +48,11 @@ class StandartDepartment:
                 url = None
 
             announcement = {"title": title, "content": None, "url": url}
+            print(announcement)
             new_announcements.append(announcement)
 
         return new_announcements
+
+
+standard = StandartDepartment('Test', 'http://www.ydyo.hacettepe.edu.tr/')
+standard.get_announcements()

--- a/scraper/standart.py
+++ b/scraper/standart.py
@@ -48,11 +48,6 @@ class StandartDepartment:
                 url = None
 
             announcement = {"title": title, "content": None, "url": url}
-            print(announcement)
             new_announcements.append(announcement)
 
         return new_announcements
-
-
-standard = StandartDepartment('Test', 'http://www.ydyo.hacettepe.edu.tr/')
-standard.get_announcements()


### PR DESCRIPTION
There was a problem that some URL's contained invalid path those contain HTML tags (especially in<img_src=_fshacettepedepartment_-_number_ format) as mentioned in #15.

The problem is solved by using two RegEx patterns, one for extracting the valid path (mentioned in the linked issue) and the another for replacing the invalid path. Invalid ones also appear in external links, thus, no matter whether the URL is internal/external, it checks and fixes.